### PR TITLE
Delay lock creation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = 'Stupid Vector Store (SVS): a vector database for the rest of us'
 readme = "README.md"
 requires-python = ">=3.8"
-license = "MIT"
+license-expression = "MIT"
 keywords = ["vector", "embeddings", "database", "semantic", "search", "store", "stupid"]
 authors = [
   { name = "Ryan Henning", email = "ryan@rhobota.com" },

--- a/src/svs/__init__.py
+++ b/src/svs/__init__.py
@@ -19,4 +19,4 @@ __all__ = [
     'make_openai_embeddings_func',
 ]
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/src/svs/util.py
+++ b/src/svs/util.py
@@ -36,11 +36,12 @@ def locked(
     Decorator for async functions to lock them so that they can only be
     executed *serially* (rather than *currently*).
     """
-    if lock is None:
-        lock = asyncio.Lock()
     def decorator(wrapped: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
         @functools.wraps(wrapped)
         async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            nonlocal lock
+            if lock is None:
+                lock = asyncio.Lock()
             async with lock:
                 return await wrapped(*args, **kwargs)
         return wrapper


### PR DESCRIPTION
We'll wait to the last moment to create asyncio locks. That's because a lock, when it is constructed, calls `asyncio.get_event_loop()` which creates an event loop when one does not yet exist.

That's fine in many cases, but there are some cases when it's not fine. E.g. If a lock is created at module-load time (at which time there will be no event loop, so that lock's creation will create a new event loop), but then _you_ create your own event loop as part of your application startup, then now you have _two_ event loops when you didn't want two!

Indeed, there were two places in SVS when we could get a lock created a module-load-time (before this PR):
- in the `locked()` decorator; decorators on module-level functions run at module-load time
- in the AsyncKB constructor; user code may want to instantiate a global (module-level) AsyncKB, which would have create a lock at module-load time.

Both are fixed in this PR.

Some people coming from _threading_ locks will be screaming right now because it looks like waiting until the last moment to construct a lock is _ABSOLUTE INSANITY_. Well, in the world of asyncio ("green threads", "coroutines" or whatever you want to call it), there is only one OS-level thread and you get deterministic context switching only at `await` keywords, so it's safe to wait like we're doing.