### PR TITLE
Optional index filters to `kb.retrieve`.

### DIFF
--- a/src/svs/kb.py
+++ b/src/svs/kb.py
@@ -17,6 +17,7 @@ from typing import (
 )
 
 import numpy as np
+from numpy.typing import NDArray
 
 import networkx as nx  # type: ignore
 
@@ -42,6 +43,7 @@ from .util import (
     get_top_pairs,
     resolve_to_local_uncompressed_file,
     delete_file_if_exists,
+    apply_candidate_and_disqualified_indexes,
 )
 
 import logging
@@ -1172,6 +1174,8 @@ class AsyncKB:
         self,
         query: str,
         n: int,
+        candidate_indexes: Optional[Union[NDArray[np.int32], List[int]]] = None,
+        disqualified_indexes: Optional[Union[NDArray[np.int32], List[int]]] = None,
     ) -> List[Retrieval]:
         _LOG.info(f"retrieving {n} documents with query string: {query}")
         loop = asyncio.get_running_loop()
@@ -1183,10 +1187,12 @@ class AsyncKB:
         _LOG.info("got embedding for query!")
         def superheavy() -> List[Tuple[float, int]]:
             x = np.dot(embeddings_matrix, query_vec)  # numpy go brrr
-            emb_ids = []
-            for score, index in get_top_k(x, n):
-                emb_ids.append((score, int(emb_id_lookup[index])))
-            return emb_ids
+            x = apply_candidate_and_disqualified_indexes(
+                x,
+                candidate_indexes,
+                disqualified_indexes,
+            )
+            return get_top_k(x, n)
         emb_ids = await loop.run_in_executor(None, superheavy)
         _LOG.info(f"computed {embeddings_matrix.shape[0]} cosine similarities")
         async with self._get_lock():
@@ -1609,6 +1615,8 @@ class KB:
         self,
         query: str,
         n: int,
+        candidate_indexes: Optional[Union[NDArray[np.int32], List[int]]] = None,
+        disqualified_indexes: Optional[Union[NDArray[np.int32], List[int]]] = None,
     ) -> List[Retrieval]:
         _LOG.info(f"retrieving {n} documents with query string: {query}")
         assert self.db is not None
@@ -1621,6 +1629,11 @@ class KB:
         _LOG.info("got embedding for query!")
         def superheavy() -> List[Tuple[float, int]]:
             x = np.dot(embeddings_matrix, query_vec)  # numpy go brrr
+            x = apply_candidate_and_disqualified_indexes(
+                x,
+                candidate_indexes,
+                disqualified_indexes,
+            )
             emb_ids = []
             for score, index in get_top_k(x, n):
                 emb_ids.append((score, int(emb_id_lookup[index])))

--- a/src/svs/util.py
+++ b/src/svs/util.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 from pathlib import Path
 
 import numpy as np
+from numpy.typing import NDArray
 
 from typing import (
     Optional, Union, Dict, List, Tuple,
@@ -231,6 +232,31 @@ def get_top_pairs(pairwise_scores_as_matrix: np.ndarray, top_k: int) -> List[Tup
         )
         for score, index_index in top
     ]
+
+
+def resolve_indexes_type(indexes: Union[NDArray[np.int32], List[int]]) -> NDArray[np.int32]:
+    if not isinstance(indexes, np.ndarray):
+        indexes = np.array(indexes, dtype=np.int32)
+    return indexes
+
+
+def apply_candidate_and_disqualified_indexes(
+    x: np.ndarray,
+    candidate_indexes: Optional[Union[NDArray[np.int32], List[int]]] = None,
+    disqualified_indexes: Optional[Union[NDArray[np.int32], List[int]]] = None,
+) -> np.ndarray:
+    x = x.copy() # Don't modify in place - that'd be too sneaky!
+    if disqualified_indexes is not None:
+        # Make these indexes impossible to be the top-k.
+        x[resolve_indexes_type(disqualified_indexes)] = -np.inf
+    if candidate_indexes is not None:
+        # Make ALL BUT these indexes impossible to be the top-k.
+        inferred_disqualified_indexes = np.setdiff1d(
+            np.arange(len(x)),
+            resolve_indexes_type(candidate_indexes),
+        )
+        x[inferred_disqualified_indexes] = -np.inf
+    return x
 
 
 def chunkify(seq: List[T], n: int) -> List[List[T]]:

--- a/tests/test_kb.py
+++ b/tests/test_kb.py
@@ -1780,6 +1780,17 @@ def test_kb_retrieve_et_al():
     assert docs[1]['doc']['text'] == 'first doc'
     assert docs[2]['doc']['text'] == 'second doc'
 
+    # Test candidate_indexes and disqualified_indexes.
+    # Only allow the least similar doc, and make sure that's the one found.
+    # In this case, "second doc" is least similar, which has index == 2.
+    docs = kb.retrieve('... third ...', n=1, candidate_indexes=[2])
+    assert len(docs) == 1
+    assert docs[0]['doc']['text'] == 'second doc'
+    # Same test but using disqualified instead.
+    docs = kb.retrieve('... third ...', n=1, disqualified_indexes=[0, 1])
+    assert len(docs) == 1
+    assert docs[0]['doc']['text'] == 'second doc'
+
     kb.close()
 
     # Pairwise scores:


### PR DESCRIPTION
Sometimes documents need to be disqualified for reasons other than embedding similarity. By allowing for optional hard filters on the data, we can let the caller segment the data before getting similarity-based results.